### PR TITLE
Enable save_work=no

### DIFF
--- a/refractasnapshot
+++ b/refractasnapshot
@@ -370,7 +370,7 @@ while true; do
 		
 		squash_filesystem
 		make_iso_fs
-		#cleanup
+		cleanup
 		final_message
 	
 		exit 0 ;;


### PR DESCRIPTION
I was wondering when I changed `save_work` to no why it wasn't getting rid of the whole `work_dir` -- it appears it wasn't enabled.